### PR TITLE
Fix demo and tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,16 +2,22 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 25 19:55:36 CEST 2016
+#Wed Sep 06 10:52:36 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -60,7 +60,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:26.0.2'
     compile 'com.commit451:PhotoView:1.2.4'
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -28,12 +28,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 7
         versionName "1.0.0"
     }
@@ -60,7 +60,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:26.0.1'
     compile 'com.commit451:PhotoView:1.2.4'
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'checkstyle'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         applicationId "es.voghdev.pdfviewpager"
@@ -39,7 +39,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies{
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:26.0.1'
     compile project(":library")
 
     testCompile 'junit:junit:4.12'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -39,7 +39,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies{
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:26.0.2'
     compile project(":library")
 
     testCompile 'junit:junit:4.12'

--- a/sample/src/main/java/es/voghdev/pdfviewpager/AssetOnSDActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/AssetOnSDActivity.java
@@ -75,7 +75,9 @@ public class AssetOnSDActivity extends BaseSampleActivity {
     protected void onDestroy() {
         super.onDestroy();
 
-        ((BasePDFPagerAdapter) pdfViewPager.getAdapter()).close();
+        if (pdfViewPager != null) {
+            ((BasePDFPagerAdapter) pdfViewPager.getAdapter()).close();
+        }
     }
 
     public static void open(Context context) {

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">PdfViewPager samples</string>
     <string name="remote_pdf_url">Remote PDF URL</string>
-    <string name="sample_pdf_url">http://partners.adobe.com/public/developer/en/xml/AdobeXMLFormsSamples.pdf</string>
+    <string name="sample_pdf_url">http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf</string>
     <string name="download">Tap to start download</string>
     <string name="asset_on_sd">Asset on SD card example</string>
     <string name="asset_on_xml">Asset on XML example</string>


### PR DESCRIPTION
The demo and tools needed to be updated to run on the latest version of the support repositories. I also fixed the remote PDF URL to point to a downloadable PDF, so all tests pass. With these fixes, you should be able to run the demo/project in the latest version of Android Studio (2.3.3 as of this pull request).