### PR TITLE
Allow for initializing remote pdf from code

### DIFF
--- a/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
@@ -31,11 +31,13 @@ public class RemotePDFViewPager extends ViewPager implements DownloadFile.Listen
     protected Context context;
     protected DownloadFile.Listener listener;
 
+    private boolean hasInitialized = false;
+
     public RemotePDFViewPager(Context context, String pdfUrl, DownloadFile.Listener listener) {
         super(context);
         this.context = context;
         this.listener = listener;
-        init(pdfUrl);
+        initializeDownload(pdfUrl);
     }
 
     public RemotePDFViewPager(Context context, AttributeSet attrs) {
@@ -44,10 +46,17 @@ public class RemotePDFViewPager extends ViewPager implements DownloadFile.Listen
         init(attrs);
     }
 
-    private void init(String pdfUrl) {
-        DownloadFile downloadFile = new DownloadFileUrlConnectionImpl(context, new Handler(), this);
-        downloadFile.download(pdfUrl,
-                new File(context.getCacheDir(), FileUtil.extractFileNameFromURL(pdfUrl)).getAbsolutePath());
+    public void setDownloadFileListener(DownloadFile.Listener listener) {
+        this.listener = listener;
+    }
+
+    public void initializeDownload(String pdfUrl) {
+        if (!hasInitialized && pdfUrl != null && !pdfUrl.equals("")) {
+            DownloadFile downloadFile = new DownloadFileUrlConnectionImpl(context, new Handler(), this);
+            downloadFile.download(pdfUrl,
+                    new File(context.getCacheDir(), FileUtil.extractFileNameFromURL(pdfUrl)).getAbsolutePath());
+            hasInitialized = true;
+        }
     }
 
     private void init(AttributeSet attrs) {
@@ -58,7 +67,7 @@ public class RemotePDFViewPager extends ViewPager implements DownloadFile.Listen
             String pdfUrl = a.getString(R.styleable.PDFViewPager_pdfUrl);
 
             if (pdfUrl != null && pdfUrl.length() > 0) {
-                init(pdfUrl);
+                initializeDownload(pdfUrl);
             }
 
             a.recycle();

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/remote/DownloadFileUrlConnectionImpl.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/remote/DownloadFileUrlConnectionImpl.java
@@ -80,6 +80,7 @@ public class DownloadFileUrlConnectionImpl implements DownloadFile {
                     notifyFailureOnUiThread(e);
                 }
 
+
                 notifySuccessOnUiThread(url, destinationPath);
             }
         }).start();

--- a/sample/src/main/java/es/voghdev/pdfviewpager/RemotePDFActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/RemotePDFActivity.java
@@ -44,6 +44,8 @@ public class RemotePDFActivity extends BaseSampleActivity implements DownloadFil
         root = (LinearLayout) findViewById(R.id.remote_pdf_root);
         etPdfUrl = (EditText) findViewById(R.id.et_pdfUrl);
         btnDownload = (Button) findViewById(R.id.btn_download);
+        remotePDFViewPager = (RemotePDFViewPager) findViewById(R.id.pdfViewPager);
+        remotePDFViewPager.setDownloadFileListener(this);
 
         setDownloadButtonListener();
     }
@@ -63,8 +65,9 @@ public class RemotePDFActivity extends BaseSampleActivity implements DownloadFil
         btnDownload.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                remotePDFViewPager = new RemotePDFViewPager(ctx, getUrlFromEditText(), listener);
-                remotePDFViewPager.setId(R.id.pdfViewPager);
+                //remotePDFViewPager = new RemotePDFViewPager(ctx, getUrlFromEditText(), listener);
+                //remotePDFViewPager.setId(R.id.pdfViewPager);
+                remotePDFViewPager.initializeDownload(getUrlFromEditText());
                 hideDownloadButton();
             }
         });

--- a/sample/src/main/java/es/voghdev/pdfviewpager/RemotePDFActivity.java
+++ b/sample/src/main/java/es/voghdev/pdfviewpager/RemotePDFActivity.java
@@ -65,8 +65,6 @@ public class RemotePDFActivity extends BaseSampleActivity implements DownloadFil
         btnDownload.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                //remotePDFViewPager = new RemotePDFViewPager(ctx, getUrlFromEditText(), listener);
-                //remotePDFViewPager.setId(R.id.pdfViewPager);
                 remotePDFViewPager.initializeDownload(getUrlFromEditText());
                 hideDownloadButton();
             }

--- a/sample/src/main/res/layout/activity_remote_pdf.xml
+++ b/sample/src/main/res/layout/activity_remote_pdf.xml
@@ -18,5 +18,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/download"/>
+
+
+    <es.voghdev.pdfviewpager.library.RemotePDFViewPager
+        android:id="@+id/pdfViewPager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
 </LinearLayout>
 


### PR DESCRIPTION
Previously, you were unable to initialize a remote PDF view pager from XML due to the required constructor that took the PDF URL. This pull request allows you to start the download from code, which allows you to setup your remote view pager in XML. I've updated the sample accordingly.