### PR TITLE
Added ability to set headers for remote requests

### DIFF
--- a/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
@@ -22,6 +22,7 @@ import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 
 import java.io.File;
+import java.util.Map;
 
 import es.voghdev.pdfviewpager.library.remote.DownloadFile;
 import es.voghdev.pdfviewpager.library.remote.DownloadFileUrlConnectionImpl;
@@ -30,12 +31,21 @@ import es.voghdev.pdfviewpager.library.util.FileUtil;
 public class RemotePDFViewPager extends ViewPager implements DownloadFile.Listener {
     protected Context context;
     protected DownloadFile.Listener listener;
+    private Map<String, String> headers;
 
     public RemotePDFViewPager(Context context, String pdfUrl, DownloadFile.Listener listener) {
         super(context);
         this.context = context;
         this.listener = listener;
         init(pdfUrl);
+    }
+
+    public RemotePDFViewPager(Context context, String pdfUrl, DownloadFile.Listener listener, Map<String, String> headers) {
+        super(context);
+        this.context = context;
+        this.listener = listener;
+        this.headers = headers;
+        init(pdfUrl, headers);
     }
 
     public RemotePDFViewPager(Context context, AttributeSet attrs) {
@@ -48,6 +58,12 @@ public class RemotePDFViewPager extends ViewPager implements DownloadFile.Listen
         DownloadFile downloadFile = new DownloadFileUrlConnectionImpl(context, new Handler(), this);
         downloadFile.download(pdfUrl,
                 new File(context.getCacheDir(), FileUtil.extractFileNameFromURL(pdfUrl)).getAbsolutePath());
+    }
+
+    private void init(String pdfUrl, Map<String, String> headers) {
+        DownloadFile downloadFile = new DownloadFileUrlConnectionImpl(context, new Handler(), this);
+        downloadFile.download(pdfUrl,
+                new File(context.getCacheDir(), FileUtil.extractFileNameFromURL(pdfUrl)).getAbsolutePath(), headers);
     }
 
     private void init(AttributeSet attrs) {

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
@@ -40,7 +40,10 @@ public class RemotePDFViewPager extends ViewPager implements DownloadFile.Listen
         init(pdfUrl);
     }
 
-    public RemotePDFViewPager(Context context, String pdfUrl, DownloadFile.Listener listener, Map<String, String> headers) {
+    public RemotePDFViewPager(Context context,
+			String pdfUrl,
+			DownloadFile.Listener listener,
+			Map<String, String> headers) {
         super(context);
         this.context = context;
         this.listener = listener;

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
@@ -40,9 +40,9 @@ public class RemotePDFViewPager extends ViewPager implements DownloadFile.Listen
     }
 
     public RemotePDFViewPager(Context context,
-			String pdfUrl,
-			DownloadFile.Listener listener,
-			Map<String, String> headers) {
+            String pdfUrl,
+            DownloadFile.Listener listener,
+            Map<String, String> headers) {
         super(context);
         this.context = context;
         this.listener = listener;

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
@@ -31,7 +31,6 @@ import es.voghdev.pdfviewpager.library.util.FileUtil;
 public class RemotePDFViewPager extends ViewPager implements DownloadFile.Listener {
     protected Context context;
     protected DownloadFile.Listener listener;
-    private Map<String, String> headers;
 
     public RemotePDFViewPager(Context context, String pdfUrl, DownloadFile.Listener listener) {
         super(context);
@@ -47,7 +46,6 @@ public class RemotePDFViewPager extends ViewPager implements DownloadFile.Listen
         super(context);
         this.context = context;
         this.listener = listener;
-        this.headers = headers;
         init(pdfUrl, headers);
     }
 

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/remote/DownloadFile.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/remote/DownloadFile.java
@@ -15,8 +15,12 @@
  */
 package es.voghdev.pdfviewpager.library.remote;
 
+import java.util.Map;
+
 public interface DownloadFile {
     void download(String url, String destinationPath);
+
+    void download(String url, String destinationPath, Map<String, String> headers);
 
     interface Listener {
         void onSuccess(String url, String destinationPath);

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/view/LegacyPDFView.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/view/LegacyPDFView.java
@@ -16,7 +16,6 @@
 package es.voghdev.pdfviewpager.library.view;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.os.Handler;
 import android.util.AttributeSet;
 import android.view.View;

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/view/LegacyPDFView.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/view/LegacyPDFView.java
@@ -73,13 +73,13 @@ public class LegacyPDFView extends LinearLayout implements DownloadFile.Listener
             downloadFile = new DownloadFileUrlConnectionImpl(getContext(), new Handler(), this);
         }
 
-        if (attrs != null) {
-            TypedArray a;
+//        if (attrs != null) {
+//            TypedArray a = null;
 
-            a = getContext().obtainStyledAttributes(attrs, R.styleable.LegacyPDFView);
+//            a = getContext().obtainStyledAttributes(attrs, R.styleable.LegacyPDFView);
 
-            a.recycle();
-        }
+//            a.recycle();
+//        }
     }
 
     protected boolean viewFound(View root, int id) {


### PR DESCRIPTION
To achieve this instantiate RemotePDFViewPager additionally with a Map<String, String> of the headers
DownloadFile now has an additional method to start a download with a map of headers
LegacyPDFView fails on getting the styledAttributes of LegacyPDFView, so I commented the branch