### PR TITLE
Prevent notify both failure and success

### DIFF
--- a/library/src/main/java/es/voghdev/pdfviewpager/library/remote/DownloadFileUrlConnectionImpl.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/remote/DownloadFileUrlConnectionImpl.java
@@ -73,14 +73,13 @@ public class DownloadFileUrlConnectionImpl implements DownloadFile {
 
                     urlConnection.disconnect();
                     fileOutput.close();
-
+                    notifySuccessOnUiThread(url, destinationPath);
                 } catch (MalformedURLException e) {
                     notifyFailureOnUiThread(e);
                 } catch (IOException e) {
                     notifyFailureOnUiThread(e);
                 }
 
-                notifySuccessOnUiThread(url, destinationPath);
             }
         }).start();
     }


### PR DESCRIPTION
`onSuccess` was called right after `onFailure` when you don't have an internet connection, or the downloading task was failed.
it also fixe_s #72 