### PR TITLE
Fix IllegalArgumentException while zooming out

### DIFF
--- a/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/RemotePDFViewPager.java
@@ -20,6 +20,7 @@ import android.content.res.TypedArray;
 import android.os.Handler;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
+import android.view.MotionEvent;
 
 import java.io.File;
 
@@ -96,6 +97,20 @@ public class RemotePDFViewPager extends ViewPager implements DownloadFile.Listen
     @Override
     public void onProgressUpdate(int progress, int total) {
         listener.onProgressUpdate(progress, total);
+    }
+
+    /**
+     * PDFViewPager uses PhotoView, so this bugfix should be added
+     * Issue explained in https://github.com/chrisbanes/PhotoView
+     */
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        try {
+            return super.onInterceptTouchEvent(ev);
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            return false;
+        }
     }
 
     public class NullListener implements DownloadFile.Listener {


### PR DESCRIPTION
You already knew this problem because these codes already existed 
https://github.com/voghDev/PdfViewPager/blob/master/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java#L77
https://github.com/voghDev/PdfViewPager/blob/master/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPagerZoom.java#L72
But you forgot to add it to RemotePDFViewPager