### PR TITLE
Support multiple PDF paths

### DIFF
--- a/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java
@@ -96,11 +96,12 @@ public class PDFViewPager extends ViewPager {
         if (onPdfChangeListeners == null) {
             onPdfChangeListeners = new ArrayList<>();
         }
-        OnPageChangeListener onPageChangeListener = new SimpleOnPageChangeListener() {
+        OnPageChangeListener onPageChangeListener = new OnPageChangeListener() {
             private int prevPdfIndex = -1;
 
             @Override
             public void onPageSelected(int position) {
+                listener.onPageSelected(position);
                 LocalPosition localPosition = pdfPagerAdapter.getLocalPosition(position);
                 if (localPosition.pdfIndex == prevPdfIndex) {
                     return;
@@ -108,6 +109,16 @@ public class PDFViewPager extends ViewPager {
 
                 prevPdfIndex = localPosition.pdfIndex;
                 listener.onPdfSelected(localPosition.pdfIndex);
+            }
+
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+                listener.onPageScrolled(position, positionOffset, positionOffsetPixels);
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int state) {
+                listener.onPageScrollStateChanged(state);
             }
         };
         addOnPageChangeListener(onPageChangeListener);

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java
@@ -21,11 +21,12 @@ import android.support.annotation.NonNull;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
+import android.view.View;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import es.voghdev.pdfviewpager.library.adapter.BasePDFPagerAdapter;
+import es.voghdev.pdfviewpager.library.adapter.LocalPosition;
 import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
 
 public class PDFViewPager extends ViewPager {
@@ -100,7 +101,7 @@ public class PDFViewPager extends ViewPager {
 
             @Override
             public void onPageSelected(int position) {
-                BasePDFPagerAdapter.LocalPosition localPosition = pdfPagerAdapter.getLocalPosition(position);
+                LocalPosition localPosition = pdfPagerAdapter.getLocalPosition(position);
                 if (localPosition.pdfIndex == prevPdfIndex) {
                     return;
                 }
@@ -120,6 +121,16 @@ public class PDFViewPager extends ViewPager {
             }
             onPdfChangeListeners.clear();
         }
+    }
+
+    public View findViewAtLocalPosition(LocalPosition localPosition) {
+        int globalPosition = pdfPagerAdapter.getGlobalPosition(localPosition);
+        return findViewAtGlobalPosition(globalPosition);
+    }
+
+    public View findViewAtGlobalPosition(int position) {
+        String tag = pdfPagerAdapter.getTag(position);
+        return findViewWithTag(tag);
     }
 
     public static abstract class OnPdfChangeListener extends SimpleOnPageChangeListener {

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPager.java
@@ -26,10 +26,10 @@ import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
 public class PDFViewPager extends ViewPager {
     protected Context context;
 
-    public PDFViewPager(Context context, String pdfPath) {
+    public PDFViewPager(Context context, String... pdfPaths) {
         super(context);
         this.context = context;
-        init(pdfPath);
+        init(pdfPaths);
     }
 
     public PDFViewPager(Context context, AttributeSet attrs) {
@@ -38,8 +38,8 @@ public class PDFViewPager extends ViewPager {
         init(attrs);
     }
 
-    protected void init(String pdfPath) {
-        initAdapter(context, pdfPath);
+    protected void init(String... pdfPaths) {
+        initAdapter(context, pdfPaths);
     }
 
     protected void init(AttributeSet attrs) {
@@ -52,7 +52,7 @@ public class PDFViewPager extends ViewPager {
             TypedArray a;
 
             a = context.obtainStyledAttributes(attrs, R.styleable.PDFViewPager);
-            String assetFileName = a.getString(R.styleable.PDFViewPager_assetFileName);
+            final String assetFileName = a.getString(R.styleable.PDFViewPager_assetFileName);
 
             if (assetFileName != null && assetFileName.length() > 0) {
                 initAdapter(context, assetFileName);
@@ -62,9 +62,9 @@ public class PDFViewPager extends ViewPager {
         }
     }
 
-    protected void initAdapter(Context context, String pdfPath) {
+    protected void initAdapter(Context context, String... pdfPaths) {
         setAdapter(new PDFPagerAdapter.Builder(context)
-                .setPdfPath(pdfPath)
+                .setPdfPaths(pdfPaths)
                 .setOffScreenSize(getOffscreenPageLimit())
                 .create());
     }

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPagerZoom.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/PDFViewPagerZoom.java
@@ -24,17 +24,17 @@ import es.voghdev.pdfviewpager.library.adapter.PDFPagerAdapter;
 import es.voghdev.pdfviewpager.library.adapter.PdfScale;
 
 public class PDFViewPagerZoom extends PDFViewPager {
-    public PDFViewPagerZoom(Context context, String pdfPath) {
-        super(context, pdfPath);
+    public PDFViewPagerZoom(Context context, String... pdfPaths) {
+        super(context, pdfPaths);
     }
 
     public PDFViewPagerZoom(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 
-    protected void initAdapter(Context context, String pdfPath) {
+    protected void initAdapter(Context context, String... pdfPaths) {
         setAdapter(new PDFPagerAdapter.Builder(context)
-                .setPdfPath(pdfPath)
+                .setPdfPaths(pdfPaths)
                 .setOffScreenSize(getOffscreenPageLimit())
                 .create()
         );
@@ -55,7 +55,7 @@ public class PDFViewPagerZoom extends PDFViewPager {
 
             if (assetFileName != null && assetFileName.length() > 0) {
                 setAdapter(new PDFPagerAdapter.Builder(context)
-                        .setPdfPath(assetFileName)
+                        .setPdfPaths(assetFileName)
                         .setScale(scale)
                         .setOffScreenSize(getOffscreenPageLimit())
                         .create());

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
@@ -140,7 +140,7 @@ public class BasePDFPagerAdapter extends PagerAdapter {
             return v;
         }
 
-        LocalPosition localPosition = getLocalPosition(renderers, position);
+        LocalPosition localPosition = getLocalPosition(position);
         PdfRenderer.Page page = getPDFPage(renderers.get(localPosition.pdfIndex), localPosition.pageIndex);
 
         Bitmap bitmap = bitmapContainers
@@ -160,7 +160,7 @@ public class BasePDFPagerAdapter extends PagerAdapter {
         return renderer.openPage(position);
     }
 
-    LocalPosition getLocalPosition(Iterable<PdfRenderer> renderers, int globalPosition) {
+    public LocalPosition getLocalPosition(int globalPosition) {
         Iterator<PdfRenderer> rendererIterator = renderers.iterator();
         int pdfIndex = 0;
         int localPageIndex = globalPosition;
@@ -215,9 +215,9 @@ public class BasePDFPagerAdapter extends PagerAdapter {
         return view == (View) object;
     }
 
-    protected class LocalPosition {
-        final int pdfIndex;
-        final int pageIndex;
+    public class LocalPosition {
+        public final int pdfIndex;
+        public final int pageIndex;
 
         LocalPosition(int pdfIndex, int pageIndex) {
             this.pdfIndex = pdfIndex;

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
@@ -150,6 +150,7 @@ public class BasePDFPagerAdapter extends PagerAdapter {
         page.close();
 
         iv.setImageBitmap(bitmap);
+        v.setTag(getTag(position));
         ((ViewPager) container).addView(v, 0);
 
         return v;
@@ -176,6 +177,30 @@ public class BasePDFPagerAdapter extends PagerAdapter {
         }
 
         throw new IndexOutOfBoundsException();
+    }
+
+    public int getGlobalPosition(LocalPosition localPosition) {
+        int globalPosition = 0;
+
+        if (localPosition.pdfIndex >= renderers.size()) {
+            throw new IndexOutOfBoundsException("PDF index is greater than number of PDFs");
+        }
+
+        if (localPosition.pageIndex >= renderers.get(localPosition.pdfIndex).getPageCount()) {
+            throw new IndexOutOfBoundsException("Page index is greater than the PDF page count");
+        }
+
+        for (int i = 0; i < localPosition.pdfIndex; i++) {
+            globalPosition += renderers.get(i).getPageCount();
+        }
+
+        globalPosition += localPosition.pageIndex;
+
+        return globalPosition;
+    }
+
+    public String getTag(int globalPosition) {
+        return String.valueOf(globalPosition);
     }
 
     @Override
@@ -213,16 +238,5 @@ public class BasePDFPagerAdapter extends PagerAdapter {
     @Override
     public boolean isViewFromObject(View view, Object object) {
         return view == (View) object;
-    }
-
-    public class LocalPosition {
-        public final int pdfIndex;
-        public final int pageIndex;
-
-        LocalPosition(int pdfIndex, int pageIndex) {
-            this.pdfIndex = pdfIndex;
-            this.pageIndex = pageIndex;
-
-        }
     }
 }

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/BasePDFPagerAdapter.java
@@ -193,7 +193,7 @@ public class BasePDFPagerAdapter extends PagerAdapter {
     }
 
     protected void releaseAllBitmaps() {
-        for(BitmapContainer bitmapContainer: bitmapContainers) {
+        for (BitmapContainer bitmapContainer : bitmapContainers) {
             bitmapContainer.clear();
         }
     }

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/LocalPosition.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/LocalPosition.java
@@ -1,0 +1,11 @@
+package es.voghdev.pdfviewpager.library.adapter;
+
+public class LocalPosition {
+    public final int pdfIndex;
+    public final int pageIndex;
+
+    public LocalPosition(int pdfIndex, int pageIndex) {
+        this.pdfIndex = pdfIndex;
+        this.pageIndex = pageIndex;
+    }
+}

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapter.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapter.java
@@ -59,6 +59,7 @@ public class PDFPagerAdapter extends BasePDFPagerAdapter {
         page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY);
         page.close();
 
+        v.setTag(getTag(position));
         ((ViewPager) container).addView(v, 0);
 
         return v;

--- a/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapter.java
+++ b/library/src/main/java/es/voghdev/pdfviewpager/library/adapter/PDFPagerAdapter.java
@@ -49,7 +49,7 @@ public class PDFPagerAdapter extends BasePDFPagerAdapter {
             return v;
         }
 
-        LocalPosition localPosition = getLocalPosition(renderers, position);
+        LocalPosition localPosition = getLocalPosition(position);
         PdfRenderer.Page page = getPDFPage(renderers.get(localPosition.pdfIndex), localPosition.pageIndex);
 
         Bitmap bitmap = bitmapContainers

--- a/sample/src/androidTest/java/es/voghdev/pdfviewpager/sample/Sample2Tests.java
+++ b/sample/src/androidTest/java/es/voghdev/pdfviewpager/sample/Sample2Tests.java
@@ -80,7 +80,7 @@ public class Sample2Tests extends BaseTest {
 
         onView(withText(R.string.menu_sample2_txt)).perform(click());
         onView(withId(R.id.btn_download)).perform(click());
-        idlingResource = new WaitIdlingResource(System.currentTimeMillis(), 1500);
+        idlingResource = new WaitIdlingResource(System.currentTimeMillis(), 10000);
         Espresso.registerIdlingResources(idlingResource);
         onView(withId(R.id.btn_download)).check(matches(isDisplayed()));
         onView(withId(R.id.pdfViewPager)).check(matches(isDisplayed()));


### PR DESCRIPTION
This change enables the `PDFViewPager` to page through multiple PDFs.

`PdfViewPager` can be initialized with multiple PDF paths like so:

```
new PDFViewPager(context, "/path/to/file/1", "path/to/file/2", ...)
```
